### PR TITLE
Set ohai < 8 for ruby_19 platforms in gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf',  '~> 3.1.3'
-gem 'chefspec',   '~> 4.0'
-# gem 'foodcritic', '~> 3.0'
-gem 'rake',       '~> 10.1'
-gem 'rubocop',    '~> 0.24.0'
+gem 'berkshelf', '~> 3.1.3'
+gem 'chefspec',  '~> 4.0'
+gem 'rake',      '~> 10.1'
+gem 'rubocop',   '~> 0.24.0'
+gem 'ohai',      '< 8.0.0', :platforms => [:ruby_19, :mri_19, :mingw_19]
 
 group :integration do
     gem 'test-kitchen',    '~> 1.2'


### PR DESCRIPTION
Ohai 8.0.0 it's not compatible with ruby 1.9.3