### PR TITLE
* fix user/group attribute variables for newer versions of EL and Fedora

### DIFF
--- a/.buildpath
+++ b/.buildpath
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<buildpath>
+	<buildpathentry kind="src" path=""/>
+	<buildpathentry kind="con" path="org.eclipse.dltk.launching.INTERPRETER_CONTAINER"/>
+</buildpath>

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>mongodb-cookbook (opensource)</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.dltk.core.scriptbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.dltk.ruby.core.nature</nature>
+	</natures>
+</projectDescription>

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ Last-Update: Tue Nov  4 11:48:54 PST 2014
 Pending 0.16.3 Changes
 --------------------------
 * remove old runit dependency
+* fix user/group attribute variables for newer versions of EL and Fedora
 
 
 Version 0.16.2 Release Tue Nov  4 11:48:54 PST 2014

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -77,11 +77,15 @@ when 'rhel', 'fedora'
   default[:mongodb][:repo] = 'http://downloads-distro.mongodb.org/repo/redhat/os'
   default[:mongodb][:package_name] = 'mongodb-server'
   default[:mongodb][:sysconfig_file] = '/etc/sysconfig/mongodb'
-  default[:mongodb][:user] = 'mongod'
-  default[:mongodb][:group] = 'mongod'
+  # Weird user/group for older RHEL & Fedora versions
+  if (node['platform_version'].to_i < 7 && node['platform_family'] == 'rhel') \
+    || (node['platform_version'].to_i < 20 && node['platform_family'] == 'fedora')
+    default[:mongodb][:user] = 'mongod'
+    default[:mongodb][:group] = 'mongod'
+    default[:mongodb][:default_init_name] = 'mongod'
+    default[:mongodb][:instance_name] = 'mongod'
+  end
   default[:mongodb][:init_script_template] = 'redhat-mongodb.init.erb'
-  default[:mongodb][:default_init_name] = 'mongod'
-  default[:mongodb][:instance_name] = 'mongod'
   # then there is this guy
   if node['platform'] == 'centos' || node['platform'] == 'amazon'
     Chef::Log.warn("CentOS doesn't provide mongodb, forcing use of mongodb-org repo")

--- a/libraries/mongodb_config_helpers.rb
+++ b/libraries/mongodb_config_helpers.rb
@@ -9,12 +9,11 @@ module MongoDBConfigHelpers
   # - ensures consistent ordering by key name
   # - does not render entries with a value of nil or ''
   def to_boost_program_options(config)
-    config.sort
+    config.sort \
     .map do |key, value|
       next if value.nil? || value == ''
       "#{key} = #{value}"
-    end
-    .compact
-    .join("\n")
+    end \
+    .compact.join("\n")
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'edelight GmbH'
 maintainer_email  'markus.korn@edelight.de'
 license           'Apache 2.0'
 description       'Installs and configures mongodb'
-version           '0.16.3'
+version           '0.16.4'
 
 recipe 'mongodb', 'Installs and configures a single node mongodb instance'
 recipe 'mongodb::10gen_repo', 'Adds the 10gen repo to get the latest packages'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -51,7 +51,8 @@ template init_file do
     :sysconfig_file => node['mongodb']['sysconfig_file'],
     :ulimit =>         node['mongodb']['ulimit'],
     :bind_ip =>        node['mongodb']['config']['bind_ip'],
-    :port =>           node['mongodb']['config']['port']
+    :port =>           node['mongodb']['config']['port'],
+    :user =>           node[:mongodb][:user]
   )
   action :create_if_missing
 

--- a/templates/default/redhat-mongodb.init.erb
+++ b/templates/default/redhat-mongodb.init.erb
@@ -11,7 +11,7 @@
 
 NAME=<%= @provides %>
 SYSCONFIG=<%= @sysconfig_file %>
-DAEMON_USER=mongod
+DAEMON_USER=<%= @user %>
 ENABLE_MONGODB=yes
 
 SUBSYS_LOCK_FILE=/var/lock/subsys/<%= @provides %>


### PR DESCRIPTION
Also adds Eclipse project files and cleans up some Eclipse DLTK warnings, since this was all committed to the end repo at the same time. The Eclipse project files can be removed post merge if needed, and really should have been a separate commit on my end. Sorry about that.